### PR TITLE
Enable ability to change config file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,8 @@ alertmanager_config_dir: /etc/alertmanager
 alertmanager_db_dir: /var/lib/alertmanager
 alertmanager_log_dir: /var/log/alertmanager
 
+alertmanager_config_file: 'alertmanager.yml.j2'
+
 alertmanager_listen_address: '0.0.0.0:9093'
 alertmanager_external_url: 'http://localhost:9093/'
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,7 +68,7 @@
 - name: copy alertmanager config
   template:
     force: yes
-    src: "alertmanager.yml.j2"
+    src: "{{ alertmanager_config_file }}"
     dest: "{{ alertmanager_config_dir }}/alertmanager.yml"
     owner: alertmanager
     group: alertmanager


### PR DESCRIPTION
I would prefer to be able to provide my own config file in the ordinary alert-manager syntax as to reduce my lock-in on this ansible role