### PR TITLE
Make Prometheus alertmanager service restart/reload with sudo privileges

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,11 +1,13 @@
 ---
 - name: restart alertmanager
+  become: true
   systemd:
     daemon_reload: yes
     name: alertmanager
     state: restarted
 
 - name: reload alertmanager
+  become: true
   systemd:
     name: alertmanager
     state: reloaded


### PR DESCRIPTION
I'm trying to include the `cloudalchemy.alertmanager` role from our own monitoring role like this:
```
- name: Install Prometheus Alertmanager service
  become: yes
  include_role:
    name: cloudalchemy.alertmanager
  vars:
  [...]
```
This results in a fatal error, at the point when running the handler that should restart the alertmanager:
```
RUNNING HANDLER [cloudalchemy.alertmanager : restart alertmanager] ******************************************************************************************************************
fatal: [monitor]: FAILED! => {"changed": false, "msg": "failure 1 during daemon-reload: Failed to execute operation: Interactive authentication required.\n"}
```
The service could only be restarted with sudo-privileges, which in the case of an `include_role` or `import_role` won't get picked up correctly by the handler responsible for the service-restart/-reload.
This PR will make sure that the `alertmanager.service` will be restarted with the correct privileges.