### PR TITLE
Locking testinfra version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   - ANSIBLE=2.3.2
   - ANSIBLE=2.4.2
 install:
-  - pip install ansible==${ANSIBLE} ansible-lint>=3.4.15 molecule==1.25.0 docker git-semver testinfra>=1.7.0,<=1.10.1
+  - pip install ansible==${ANSIBLE} ansible-lint>=3.4.15 molecule==1.25.0 docker git-semver 'testinfra>=1.7.0,<=1.10.1'
 script:
   - molecule test
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   - ANSIBLE=2.3.2
   - ANSIBLE=2.4.2
 install:
-  - pip install ansible==${ANSIBLE} ansible-lint>=3.4.15 molecule==1.25.0 docker git-semver testinfra>=1.7.0
+  - pip install ansible==${ANSIBLE} ansible-lint>=3.4.15 molecule==1.25.0 docker git-semver testinfra>=1.7.0,<=1.10.1
 script:
   - molecule test
 deploy:


### PR DESCRIPTION
This is needed due to a bug with `ss` implementation in testinfra framework. More in https://github.com/philpep/testinfra/issues/293