### PR TITLE
Fix default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `alertmanager_hipchat_url` | "" | Hipchat webhook url |
 | `alertmanager_hipchat_auth_token` | "" | Hipchat authentication token |
 | `alertmanager_mesh` | {} | HA mesh network configuration |
-| `alertmanager_receivers` | [defaults/main.yml#L38](defaults/main.yml#L38) | A list of notification receivers. Configuration same as in [official docs](https://prometheus.io/docs/alerting/configuration/#<receiver>) |
+| `alertmanager_receivers` | [] | A list of notification receivers. Configuration same as in [official docs](https://prometheus.io/docs/alerting/configuration/#<receiver>) |
 | `alertmanager_inhibit_rules` | [] | List of inhibition rules. Same as in [official docs](https://prometheus.io/docs/alerting/configuration/#inhibit_rule) |
 | `alertmanager_route` | [defaults/main.yml#L47](defaults/main.yml#L47) | Alert routing. More in [official docs](https://prometheus.io/docs/alerting/configuration/#<route>) |
 | `alertmanager_child_routes` | [] | List of child routes. |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,12 +44,12 @@ alertmanager_mesh: {}
 #    - "{{ ansible_default_ipv4.address }}:6783"
 #    - "demo.cloudalchemy.org:6783"
 
-alertmanager_receivers:
-- name: slack
-  slack_configs:
-  - send_resolved: true
-  - api_url: $slack_api_url
-  - channel: '#alerts'
+alertmanager_receivers: []
+#- name: slack
+#  slack_configs:
+#  - send_resolved: true
+#  - api_url: $slack_api_url
+#  - channel: '#alerts'
 
 alertmanager_inhibit_rules: []
 

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,0 @@
-localhost

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -13,3 +13,9 @@
       peers:
         - "127.0.0.1:6783"
         - "demo.cloudalchemy.org:6783"
+    alertmanager_receivers:
+      - name: slack
+        slack_configs:
+          - send_resolved: true
+          - api_url: $slack_api_url
+          - channel: '#alerts'


### PR DESCRIPTION
Including by default a receiver configuration is misleading and causes example usage from README.md to fail.
This PR moves receiver config to be used only in tests.