### PR TITLE
Major rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 .molecule
 .cache
 **__pycache__**
+.pytest_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ env:
   - ANSIBLE='ansible>=2.5.0,<2.6.0'
 install:
   - pip install ${ANSIBLE} 'ansible-lint>=3.4.15' 'molecule==1.25.0' docker git-semver 'testinfra>=1.7.0,<=1.10.1'
+before_script:
+  - ansible-lint tests/playbook.yml
 script:
   - molecule test
 deploy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ We try to provide production ready ansible roles which should be as much zero-co
 
 ### Add tests
 
-We try to have as much tests written in testinfra framework as possible, so when you copy file, some template or starting some server just add couple of lines in [/tests/test)default.py](test_default.py) file. If you want to know how to write tests in testinfra, go to their [docs](http://testinfra.readthedocs.io/en/latest/index.html).
+We try to have as much tests written in testinfra framework as possible, so when you copy file, some template or starting some server just add couple of lines in [test_default.py](/tests/test_default.py) file. If you want to know how to write tests in testinfra, go to their [docs](http://testinfra.readthedocs.io/en/latest/index.html).
 
 ### Follow best practices
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 
 ```yaml
 - hosts: all
-  become: true
   roles:
     - cloudalchemy.alertmanager
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Deploy and manage Prometheus [alertmanager](https://github.com/prometheus/alertm
 ## Requirements
 
 - Ansible >= 2.3
-- go-lang installed on deployer machine (same one which ansible is installed)
 
 It would be nice to have prometheus installed somewhere
 
@@ -43,7 +42,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `alertmanager_mesh` | {} | HA mesh network configuration |
 | `alertmanager_receivers` | [] | A list of notification receivers. Configuration same as in [official docs](https://prometheus.io/docs/alerting/configuration/#<receiver>) |
 | `alertmanager_inhibit_rules` | [] | List of inhibition rules. Same as in [official docs](https://prometheus.io/docs/alerting/configuration/#inhibit_rule) |
-| `alertmanager_route` | [defaults/main.yml#L47](defaults/main.yml#L47) | Alert routing. More in [official docs](https://prometheus.io/docs/alerting/configuration/#<route>) |
+| `alertmanager_route` | {} | Alert routing. More in [official docs](https://prometheus.io/docs/alerting/configuration/#<route>) |
 | `alertmanager_child_routes` | [] | List of child routes. |
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `alertmanager_config_dir` | /etc/alertmanager | Path to directory with alertmanager configuration |
 | `alertmanager_db_dir` | /var/lib/alertmanager | Path to directory with alertmanager database |
 | `alertmanager_config_file` | 'alertmanager.yml.j2' | Variable used to provide custom alertmanager configuration file in form of ansible template |
-| `alertmanager_cli_flags` | {} | Additional configuration flags passed to prometheus binary at startup |
+| `alertmanager_config_flags_extra` | {} | Additional configuration flags passed to prometheus binary at startup |
 | `alertmanager_resolve_timeout` | 3m | Time after which an alert is declared resolved |
 | `alertmanager_smtp` | {} | SMTP (email) configuration |
 | `alertmanager_slack_api_url` | "" | Slack webhook url |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,7 +59,7 @@ alertmanager_route: {}
 #  group_by: ['alertname', 'cluster', 'service']
 #  group_wait: 30s
 #  group_interval: 5m
-#  repeat_interval: 3h
+#  repeat_interval: 4h
 #  receiver: slack
 
 alertmanager_child_routes: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,8 +6,8 @@ alertmanager_db_dir: /var/lib/alertmanager
 
 alertmanager_config_file: 'alertmanager.yml.j2'
 
-alertmanager_listen_address: '0.0.0.0:9093'
-alertmanager_external_url: 'http://localhost:9093/'
+alertmanager_web_listen_address: '0.0.0.0:9093'
+alertmanager_web_external_url: 'http://localhost:9093/'
 
 alertmanager_resolve_timeout: 3m
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
 alertmanager_version: 0.14.0
 
-alertmanager_root_dir: /opt/alertmanager
 alertmanager_config_dir: /etc/alertmanager
 alertmanager_db_dir: /var/lib/alertmanager
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,8 +12,8 @@ alertmanager_external_url: 'http://localhost:9093/'
 
 alertmanager_resolve_timeout: 3m
 
-alertmanager_cli_flags: {}
-#alertmanager_cli_flags:
+alertmanager_config_flags_extra: {}
+#alertmanager_config_flags_extra:
 #  data.retention: 10
 
 # SMTP default params

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,21 +44,23 @@ alertmanager_mesh: {}
 #    - "{{ ansible_default_ipv4.address }}:6783"
 #    - "demo.cloudalchemy.org:6783"
 
-alertmanager_receivers:
-- name: slack
-  slack_configs:
-  - send_resolved: true
-  - api_url: $slack_api_url
-  - channel: '#alerts'
+alertmanager_receivers: []
+#alertmanager_receivers:
+#- name: slack
+#  slack_configs:
+#  - send_resolved: true
+#    api_url: $slack_api_url
+#    channel: '#alerts'
 
 alertmanager_inhibit_rules: []
 
-alertmanager_route:
-  group_by: ['alertname', 'cluster', 'service']
-  group_wait: 30s
-  group_interval: 5m
-  repeat_interval: 3h
-  receiver: slack
+alertmanager_route: {}
+#alertmanager_route:
+#  group_by: ['alertname', 'cluster', 'service']
+#  group_wait: 30s
+#  group_interval: 5m
+#  repeat_interval: 3h
+#  receiver: slack
 
 alertmanager_child_routes: []
 #alertmanager_child_routes:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -7,7 +7,7 @@
     owner: alertmanager
     group: alertmanager
     mode: 0644
-    verify: "/usr/local/bin/amtool --alertmanager.url=  check-config %s"
+    validate: "/usr/local/bin/amtool --alertmanager.url=  check-config %s"
   notify:
     - restart alertmanager
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -7,6 +7,7 @@
     owner: alertmanager
     group: alertmanager
     mode: 0644
+    verify: "/usr/local/bin/amtool --alertmanager.url=  check-config %s"
   notify:
     - restart alertmanager
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,0 +1,14 @@
+---
+- name: copy alertmanager config
+  template:
+    force: yes
+    src: "{{ alertmanager_config_file }}"
+    dest: "{{ alertmanager_config_dir }}/alertmanager.yml"
+    owner: alertmanager
+    group: alertmanager
+    mode: 0644
+  notify:
+    - restart alertmanager
+
+# TODO
+#- name: copy templates

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,0 +1,80 @@
+---
+- name: create alertmanager system group
+  group:
+    name: alertmanager
+    system: yes
+    state: present
+
+- name: create alertmanager system user
+  user:
+    name: alertmanager
+    system: yes
+    shell: "/sbin/nologin"
+    group: alertmanager
+    createhome: no
+
+- name: create alertmanager directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: alertmanager
+    group: alertmanager
+    mode: 0755
+  with_items:
+    - "{{ alertmanager_root_dir }}"
+    - "{{ alertmanager_config_dir }}"
+    - "{{ alertmanager_config_dir }}/templates"
+    - "{{ alertmanager_db_dir }}"
+
+- name: download alertmanager binary to local folder
+  become: no
+  unarchive:
+    src: "https://github.com/prometheus/alertmanager/releases/download/v{{ alertmanager_version }}/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
+    dest: "/tmp"
+    remote_src: yes
+    creates: "/tmp/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/alertmanager"
+  run_once: true
+  delegate_to: localhost
+
+- name: propagate alertmanager and amtool binaries
+  copy:
+    src: "/tmp/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/{{ item }}"
+    dest: "{{ alertmanager_root_dir }}/{{ item }}"
+    mode: 0755
+    owner: alertmanager
+    group: alertmanager
+  with_items:
+    - alertmanager
+    - amtool
+  notify:
+    - restart alertmanager
+
+- name: create systemd service unit
+  template:
+    src: alertmanager.service.j2
+    dest: /etc/systemd/system/alertmanager.service
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - restart alertmanager
+
+- name: Install SELinux dependencies on RedHat OS family
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - libselinux-python
+    - policycoreutils-python
+  when:
+    - ansible_os_family == "RedHat"
+
+- name: Allow alertmanager to bind to port in SELinux on RedHat OS family
+  seport:
+    ports: "{{ alertmanager_web_listen_address.split(':')[1] }}"
+    proto: tcp
+    setype: http_port_t
+    state: present
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_virtualization_type != "docker"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -21,7 +21,6 @@
     group: alertmanager
     mode: 0755
   with_items:
-    - "{{ alertmanager_root_dir }}"
     - "{{ alertmanager_config_dir }}"
     - "{{ alertmanager_config_dir }}/templates"
     - "{{ alertmanager_db_dir }}"
@@ -39,7 +38,7 @@
 - name: propagate alertmanager and amtool binaries
   copy:
     src: "/tmp/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/{{ item }}"
-    dest: "{{ alertmanager_root_dir }}/{{ item }}"
+    dest: "/usr/local/bin/{{ item }}"
     mode: 0755
     owner: alertmanager
     group: alertmanager
@@ -78,3 +77,12 @@
   when:
     - ansible_os_family == "RedHat"
     - ansible_virtualization_type != "docker"
+
+- name: remove alertmanager binaries from old location
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - /opt/alertmanager/alertmanager
+    - /opt/alertmanager/amtool
+    - /opt/alertmanager

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- include: preflight.yml
+
 - name: create alertmanager system group
   group:
     name: alertmanager

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,98 +1,12 @@
 ---
 - include: preflight.yml
 
-- name: create alertmanager system group
-  group:
-    name: alertmanager
-    system: yes
-    state: present
+- include: install.yml
 
-- name: create alertmanager system user
-  user:
-    name: alertmanager
-    system: yes
-    shell: "/sbin/nologin"
-    group: alertmanager
-    createhome: no
+- include: configure.yml
 
-- name: create alertmanager directories
-  file:
-    path: "{{ item }}"
-    state: directory
-    owner: alertmanager
-    group: alertmanager
-    mode: 0755
-  with_items:
-    - "{{ alertmanager_root_dir }}"
-    - "{{ alertmanager_config_dir }}"
-    - "{{ alertmanager_config_dir }}/templates"
-    - "{{ alertmanager_db_dir }}"
-
-- name: download alertmanager binary to local folder
-  become: no
-  unarchive:
-    src: "https://github.com/prometheus/alertmanager/releases/download/v{{ alertmanager_version }}/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
-    dest: "/tmp"
-    remote_src: yes
-    creates: "/tmp/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/alertmanager"
-  run_once: true
-  delegate_to: localhost
-
-- name: propagate alertmanager and amtool binaries
-  copy:
-    src: "/tmp/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/{{ item }}"
-    dest: "{{ alertmanager_root_dir }}/{{ item }}"
-    mode: 0755
-    owner: alertmanager
-    group: alertmanager
-  with_items:
-    - alertmanager
-    - amtool
-  notify:
-    - restart alertmanager
-
-- name: create systemd service unit
-  template:
-    src: alertmanager.service.j2
-    dest: /etc/systemd/system/alertmanager.service
-    owner: root
-    group: root
-    mode: 0644
-  notify:
-    - restart alertmanager
-
-- name: ensure alertmanager service is enabled
+- name: ensure alertmanager service is started and enabled
   systemd:
     name: alertmanager
+    state: started
     enabled: yes
-
-- name: copy alertmanager config
-  template:
-    force: yes
-    src: "{{ alertmanager_config_file }}"
-    dest: "{{ alertmanager_config_dir }}/alertmanager.yml"
-    owner: alertmanager
-    group: alertmanager
-    mode: 0644
-  notify:
-    - restart alertmanager
-
-- name: Install SELinux dependencies on RedHat OS family
-  package:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - libselinux-python
-    - policycoreutils-python
-  when:
-    - ansible_os_family == "RedHat"
-
-- name: Allow alertmanager to bind to port in SELinux on RedHat OS family
-  seport:
-    ports: "{{ alertmanager_web_listen_address.split(':')[1] }}"
-    proto: tcp
-    setype: http_port_t
-    state: present
-  when:
-    - ansible_os_family == "RedHat"
-    - ansible_virtualization_type != "docker"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,10 +2,13 @@
 - include: preflight.yml
 
 - include: install.yml
+  become: yes
 
 - include: configure.yml
+  become: yes
 
 - name: ensure alertmanager service is started and enabled
+  become: yes
   systemd:
     name: alertmanager
     state: started

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -1,4 +1,17 @@
 ---
+- name: Backward compatibility of variables
+  set_fact:
+    alertmanager_config_flags_extra: "{{ alertmanager_cli_flags }}"
+
+- name: Fail when extra config flags are duplicating ansible variables
+  fail:
+    msg: "Detected duplicate configuration entry. Please check your ansible variables and role README.md."
+  when:
+    (alertmanager_config_flags_extra['config.file'] is defined) or
+    (alertmanager_config_flags_extra['storage.path'] is defined) or
+    (alertmanager_config_flags_extra['web.listen-address'] is defined) or
+    (alertmanager_config_flags_extra['web.external-url'] is defined)
+
 - name: Fail when there are no receivers defined
   fail:
     msg: "Configure alert receivers (`alertmanager_receivers`). Otherwise alertmanager won't know where to send alerts."

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -22,3 +22,8 @@
   fail:
     msg: "Configure alert routing (`alertmanager_route`). Otherwise alertmanager won't know how to send alerts."
   when: alertmanager_receivers == {}
+
+- name: Fail when child routes are defined not in proper place
+  fail:
+    msg: "Please recofigure `alertmanager_route` a way in which child routes are placed in `alertmanager_child_routes`."
+  when: alertmanager_route.routes is defined

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -2,6 +2,7 @@
 - name: Backward compatibility of variables
   set_fact:
     alertmanager_config_flags_extra: "{{ alertmanager_cli_flags }}"
+  when: alertmanager_cli_flags is defined
 
 - name: Fail when extra config flags are duplicating ansible variables
   fail:

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -1,0 +1,10 @@
+---
+- name: Fail when there are no receivers defined
+  fail:
+    msg: "Configure alert receivers (`alertmanager_receivers`). Otherwise alertmanager won't know where to send alerts."
+  when: alertmanager_receivers == []
+
+- name: Fail when there is no alert route defined
+  fail:
+    msg: "Configure alert routing (`alertmanager_route`). Otherwise alertmanager won't know how to send alerts."
+  when: alertmanager_receivers == {}

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -1,8 +1,18 @@
 ---
-- name: Backward compatibility of variables
+- name: Backward compatibility of variable [part 1]
   set_fact:
     alertmanager_config_flags_extra: "{{ alertmanager_cli_flags }}"
   when: alertmanager_cli_flags is defined
+
+- name: Backward compatibility of variable [part 2]
+  set_fact:
+    alertmanager_web_listen_address: "{{ alertmanager_listen_address }}"
+  when: alertmanager_listen_address is defined
+
+- name: Backward compatibility of variable [part 3]
+  set_fact:
+    alertmanager_web_external_url: "{{ alertmanager_external_url }}"
+  when: alertmanager_external_url is defined
 
 - name: Fail when extra config flags are duplicating ansible variables
   fail:

--- a/templates/alertmanager.service.j2
+++ b/templates/alertmanager.service.j2
@@ -14,7 +14,7 @@ PIDFile=/var/run/alertmanager.pid
 User=alertmanager
 Group=alertmanager
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart={{ alertmanager_root_dir }}/alertmanager \
+ExecStart=/usr/local/bin/alertmanager \
 {% for option, value in alertmanager_mesh.items() %}
 {%   if option == "peers" %}
 {%     for peer in value %}

--- a/templates/alertmanager.service.j2
+++ b/templates/alertmanager.service.j2
@@ -26,8 +26,8 @@ ExecStart=/usr/local/bin/alertmanager \
 {% endfor %}
   {{ pre }}-config.file={{ alertmanager_config_dir }}/alertmanager.yml \
   {{ pre }}-storage.path={{ alertmanager_db_dir }} \
-  {{ pre }}-web.listen-address={{ alertmanager_listen_address }} \
-  {{ pre }}-web.external-url={{ alertmanager_external_url }}{% for flag, flag_value in alertmanager_config_flags_extra.items() %} \
+  {{ pre }}-web.listen-address={{ alertmanager_web_listen_address }} \
+  {{ pre }}-web.external-url={{ alertmanager_web_external_url }}{% for flag, flag_value in alertmanager_config_flags_extra.items() %} \
   {{ pre }}-{{ flag }}={{ flag_value }}{% endfor %}
 
 SyslogIdentifier=alertmanager

--- a/templates/alertmanager.service.j2
+++ b/templates/alertmanager.service.j2
@@ -27,7 +27,7 @@ ExecStart={{ alertmanager_root_dir }}/alertmanager \
   {{ pre }}-config.file={{ alertmanager_config_dir }}/alertmanager.yml \
   {{ pre }}-storage.path={{ alertmanager_db_dir }} \
   {{ pre }}-web.listen-address={{ alertmanager_listen_address }} \
-  {{ pre }}-web.external-url={{ alertmanager_external_url }}{% for flag, flag_value in alertmanager_cli_flags.items() %} \
+  {{ pre }}-web.external-url={{ alertmanager_external_url }}{% for flag, flag_value in alertmanager_config_flags_extra.items() %} \
   {{ pre }}-{{ flag }}={{ flag_value }}{% endfor %}
 
 SyslogIdentifier=alertmanager

--- a/templates/alertmanager.yml.j2
+++ b/templates/alertmanager.yml.j2
@@ -1,28 +1,23 @@
+# {{ ansible_managed }}
+
 global:
-  # ResolveTimeout is the time after which an alert is declared resolved
-  # if it has not been updated.
   resolve_timeout: {{ alertmanager_resolve_timeout }}
 {% for key, value in alertmanager_smtp.iteritems() %}
   smtp_{{ key }}: "{{ value }}"
 {% endfor %}
 {% if alertmanager_slack_api_url != '' %}
-  # The API URL to use for Slack notifications.
   slack_api_url: {{ alertmanager_slack_api_url }}
 {% endif %}
 {% if alertmanager_pagerduty_url != '' %}
-  # The API URL to use for pagerduty notifications.
   pagerduty_url: {{ alertmanager_pagerduty_url }}
 {% endif %}
 {% if alertmanager_opsgenie_api_host != '' %}
-  # The API URL to use for opsgenie notifications.
   opsgenie_api_host: {{ alertmanager_opsgenie_api_host }}
 {% endif %}
 {% if alertmanager_hipchat_url != '' %}
-  # The API URL to use for hipchat url notifications.
   hipchat_url: {{ alertmanager_hipchat_url }}
 {% endif %}
 {% if alertmanager_hipchat_auth_token != '' %}
-  # The API URL to use for hipchat token notifications.
   hipchat_auth_token: {{ alertmanager_hipchat_auth_token }}
 {% endif %}
 templates:
@@ -31,12 +26,10 @@ templates:
 receivers:
 {{ alertmanager_receivers | to_nice_yaml(indent=2) }}
 {% endif %}
-
 {% if alertmanager_inhibit_rules != [] %}
 inhibit_rules:
 {{ alertmanager_inhibit_rules | to_nice_yaml(indent=2) }}
 {% endif %}
-
 route:
   {{ alertmanager_route | to_nice_yaml(indent=2) | indent(2, False) }}
 {% if alertmanager_child_routes != [] %}

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -1,33 +1,9 @@
 ---
 - hosts: all
   any_errors_fatal: yes
+  pre_tasks:
+    - name: Include vars
+      include_vars: vars.yml
   roles:
     - ansible-alertmanager
-  vars:
-    alertmanager_slack_api_url: "http://example.com"
-    alertmanager_listen_address: "127.0.0.1:9093"
-    alertmanager_receivers:
-    - name: slack
-      slack_configs:
-      - send_resolved: true
-        api_url: $slack_api_url
-        channel: '#alerts'
-    alertmanager_route:
-      group_by: ['alertname', 'cluster', 'service']
-      group_wait: 30s
-      group_interval: 5m
-      repeat_interval: 3h
-      receiver: slack
-    alertmanager_mesh:
-      peer-id: "{{ ansible_default_ipv4.macaddress }}"
-      listen-address: "127.0.0.1:6783"
-      nickname: "{{ ansible_hostname }}"
-      peers:
-        - "127.0.0.1:6783"
-        - "demo.cloudalchemy.org:6783"
-    alertmanager_receivers:
-      - name: slack
-        slack_configs:
-          - send_resolved: true
-          - api_url: $slack_api_url
-          - channel: '#alerts'
+

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -6,4 +6,3 @@
       include_vars: vars.yml
   roles:
     - ansible-alertmanager
-

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -6,6 +6,18 @@
   vars:
     alertmanager_slack_api_url: "http://example.com"
     alertmanager_listen_address: "127.0.0.1:9093"
+    alertmanager_receivers:
+    - name: slack
+      slack_configs:
+      - send_resolved: true
+        api_url: $slack_api_url
+        channel: '#alerts'
+    alertmanager_route:
+      group_by: ['alertname', 'cluster', 'service']
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 3h
+      receiver: slack
     alertmanager_mesh:
       peer-id: "{{ ansible_default_ipv4.macaddress }}"
       listen-address: "127.0.0.1:6783"

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -6,13 +6,13 @@ testinfra_hosts = AnsibleRunner('.molecule/ansible_inventory').get_hosts('all')
 
 def test_directories(host):
     dirs = [
-        "/opt/alertmanager",
         "/etc/alertmanager",
         "/etc/alertmanager/templates",
         "/var/lib/alertmanager"
     ]
     files = [
-        "/opt/alertmanager/alertmanager",
+        "/usr/local/bin/alertmanager",
+        "/usr/local/bin/amtool",
         "/etc/alertmanager/alertmanager.yml",
         "/etc/systemd/system/alertmanager.service"
     ]

--- a/tests/vars.yml
+++ b/tests/vars.yml
@@ -19,9 +19,3 @@ alertmanager_mesh:
   peers:
     - "127.0.0.1:6783"
     - "demo.cloudalchemy.org:6783"
-alertmanager_receivers:
-  - name: slack
-    slack_configs:
-      - send_resolved: true
-      - api_url: $slack_api_url
-      - channel: '#alerts'

--- a/tests/vars.yml
+++ b/tests/vars.yml
@@ -1,0 +1,27 @@
+alertmanager_slack_api_url: "http://example.com"
+alertmanager_listen_address: "127.0.0.1:9093"
+alertmanager_receivers:
+- name: slack
+  slack_configs:
+  - send_resolved: true
+    api_url: $slack_api_url
+    channel: '#alerts'
+alertmanager_route:
+  group_by: ['alertname', 'cluster', 'service']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 3h
+  receiver: slack
+alertmanager_mesh:
+  peer-id: "{{ ansible_default_ipv4.macaddress }}"
+  listen-address: "127.0.0.1:6783"
+  nickname: "{{ ansible_hostname }}"
+  peers:
+    - "127.0.0.1:6783"
+    - "demo.cloudalchemy.org:6783"
+alertmanager_receivers:
+  - name: slack
+    slack_configs:
+      - send_resolved: true
+      - api_url: $slack_api_url
+      - channel: '#alerts'


### PR DESCRIPTION
Adding:
- multiple preflight checks (resolves #5)
- variables which are compatible in name with ansible-prometheus, backwards compatibility is present (resolves #10)
- split variables in test playbook
- specify `become` on tasks level instead of playbook one
- split tasks/main.yml into multiple files
- linter check before running molecule
- use /usr/local/bin for binaries location

Removing:
- default alert route
- default alert receiver