### PR TITLE
Make template compatible with both Python 2 and 3

### DIFF
--- a/templates/alertmanager.yml.j2
+++ b/templates/alertmanager.yml.j2
@@ -2,7 +2,7 @@
 
 global:
   resolve_timeout: {{ alertmanager_resolve_timeout }}
-{% for key, value in alertmanager_smtp.iteritems() %}
+{% for key, value in alertmanager_smtp.items() %}
   smtp_{{ key }}: "{{ value }}"
 {% endfor %}
 {% if alertmanager_slack_api_url != '' %}


### PR DESCRIPTION
When using this role in an environment where the default python
interpreter is python3, the ansible run fails when jinja2 tries to
process `templates/alertmanager.yml.j2`.

This is because in Python 3, `dict` objects no longer have the
`.iteritems()` method (see e.g.: https://wiki.python.org/moin/Python3.0,
under "Built-in Changes").

For the purposes it's used in the template, `.items()` is functionally
equivalent to `.iteritems()` except that it also works in Python 3.

Also, the implementation for looping over dictionary k/v pairs is now 
consistent over both template files used in this role.