### PR TITLE
don't treat false, true, null as strings when templating smtp configuration

### DIFF
--- a/templates/alertmanager.yml.j2
+++ b/templates/alertmanager.yml.j2
@@ -3,7 +3,7 @@
 global:
   resolve_timeout: {{ alertmanager_resolve_timeout }}
 {% for key, value in alertmanager_smtp.items() %}
-  smtp_{{ key }}: "{{ value }}"
+  smtp_{{ key }}: {{ value }}
 {% endfor %}
 {% if alertmanager_slack_api_url != '' %}
   slack_api_url: {{ alertmanager_slack_api_url }}


### PR DESCRIPTION
fix treating smtp_require_tls value as a string, which caused amtool validation to fail