### PR TITLE
Add option to install Alertmanager from package name if defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
 | `alertmanager_version` | 0.15.2 | Alermanager package version |
+| `alertmanager_package_name` | "" | Alertmanager package name. Set this if you want to install Alertmanager from a package rather than a binary. |
 | `alertmanager_listen_address` | '0.0.0.0:9093' | Address on which alertmanager will be listening |
 | `alertmanager_external_url` | 'http://localhost:9093/' | External address on which alertmanager is available. Useful when behind reverse proxy. Ex. example.org/alertmanager |
 | `alertmanager_config_dir` | /etc/alertmanager | Path to directory with alertmanager configuration |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 alertmanager_version: 0.15.2
+alertmanager_package_name: ""
 
 alertmanager_config_dir: /etc/alertmanager
 alertmanager_db_dir: /var/lib/alertmanager

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,96 +1,107 @@
 ---
-- name: create alertmanager system group
-  group:
-    name: alertmanager
-    system: true
-    state: present
+- name: Install Alertmanager
+  block:
+    - name: Install Alertmanager from package
+      package:
+        name: "{{ alertmanager_package_name }}"
+        state: present
+  when: alertmanager_package_name is defined and alertmanager_package_name != ""
 
-- name: create alertmanager system user
-  user:
-    name: alertmanager
-    system: true
-    shell: "/sbin/nologin"
-    group: alertmanager
-    createhome: false
+- name: Install Alertmanager via tarball
+  block:
+    - name: create alertmanager system group
+      group:
+        name: alertmanager
+        system: true
+        state: present
 
-- name: create alertmanager directories
-  file:
-    path: "{{ item }}"
-    state: directory
-    owner: alertmanager
-    group: alertmanager
-    mode: 0755
-  with_items:
-    - "{{ alertmanager_config_dir }}"
-    - "{{ alertmanager_config_dir }}/templates"
-    - "{{ alertmanager_db_dir }}"
+    - name: create alertmanager system user
+      user:
+        name: alertmanager
+        system: true
+        shell: "/sbin/nologin"
+        group: alertmanager
+        createhome: false
 
-- name: download alertmanager binary to local folder
-  become: false
-  unarchive:
-    src: "https://github.com/prometheus/alertmanager/releases/download/v{{ alertmanager_version }}/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
-    dest: "/tmp"
-    remote_src: true
-    creates: "/tmp/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/alertmanager"
-  register: _download_binary
-  until: _download_binary is succeeded
-  retries: 5
-  delay: 2
-  # run_once: true
-  delegate_to: localhost
+    - name: create alertmanager directories
+      file:
+        path: "{{ item }}"
+        state: directory
+        owner: alertmanager
+        group: alertmanager
+        mode: 0755
+      with_items:
+        - "{{ alertmanager_config_dir }}"
+        - "{{ alertmanager_config_dir }}/templates"
+        - "{{ alertmanager_db_dir }}"
 
-- name: propagate alertmanager and amtool binaries
-  copy:
-    src: "/tmp/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/{{ item }}"
-    dest: "/usr/local/bin/{{ item }}"
-    mode: 0755
-    owner: alertmanager
-    group: alertmanager
-  with_items:
-    - alertmanager
-    - amtool
-  notify:
-    - restart alertmanager
+    - name: download alertmanager binary to local folder
+      become: false
+      unarchive:
+        src: "https://github.com/prometheus/alertmanager/releases/download/v{{ alertmanager_version }}/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.tar.gz"
+        dest: "/tmp"
+        remote_src: true
+        creates: "/tmp/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/alertmanager"
+      register: _download_binary
+      until: _download_binary is succeeded
+      retries: 5
+      delay: 2
+      # run_once: true
+      delegate_to: localhost
 
-- name: create systemd service unit
-  template:
-    src: alertmanager.service.j2
-    dest: /etc/systemd/system/alertmanager.service
-    owner: root
-    group: root
-    mode: 0644
-  notify:
-    - restart alertmanager
+    - name: propagate alertmanager and amtool binaries
+      copy:
+        src: "/tmp/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/{{ item }}"
+        dest: "/usr/local/bin/{{ item }}"
+        mode: 0755
+        owner: alertmanager
+        group: alertmanager
+      with_items:
+        - alertmanager
+        - amtool
+      notify:
+        - restart alertmanager
 
-- name: Install SELinux dependencies on RedHat OS family
-  package:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - libselinux-python
-    - policycoreutils-python
-  register: _download_packages
-  until: _download_packages | success
-  retries: 5
-  delay: 2
-  when:
-    - ansible_os_family == "RedHat"
+    - name: create systemd service unit
+      template:
+        src: alertmanager.service.j2
+        dest: /etc/systemd/system/alertmanager.service
+        owner: root
+        group: root
+        mode: 0644
+      notify:
+        - restart alertmanager
 
-- name: Allow alertmanager to bind to port in SELinux on RedHat OS family
-  seport:
-    ports: "{{ alertmanager_web_listen_address.split(':')[1] }}"
-    proto: tcp
-    setype: http_port_t
-    state: present
-  when:
-    - ansible_version.full is version_compare('2.4', '>=')
-    - ansible_selinux.status == "enabled"
+    - name: Install SELinux dependencies on RedHat OS family
+      package:
+        name: "{{ item }}"
+        state: present
+      with_items:
+        - libselinux-python
+        - policycoreutils-python
+      register: _download_packages
+      until: _download_packages | success
+      retries: 5
+      delay: 2
+      when:
+        - ansible_os_family == "RedHat"
 
-- name: remove alertmanager binaries from old location
-  file:
-    path: "{{ item }}"
-    state: absent
-  with_items:
-    - /opt/alertmanager/alertmanager
-    - /opt/alertmanager/amtool
-    - /opt/alertmanager
+    - name: Allow alertmanager to bind to port in SELinux on RedHat OS family
+      seport:
+        ports: "{{ alertmanager_web_listen_address.split(':')[1] }}"
+        proto: tcp
+        setype: http_port_t
+        state: present
+      when:
+        - ansible_version.full is version_compare('2.4', '>=')
+        - ansible_selinux.status == "enabled"
+
+    - name: remove alertmanager binaries from old location
+      file:
+        path: "{{ item }}"
+        state: absent
+      with_items:
+        - /opt/alertmanager/alertmanager
+        - /opt/alertmanager/amtool
+        - /opt/alertmanager
+  when: alertmanager_package_name is defined and alertmanager_package_name == ""


### PR DESCRIPTION
This attempts to resolve #49  because we also have the constraint of not being able to talk to Github :(