### PR TITLE
Update opsgenie global configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `alertmanager_smtp` | {} | SMTP (email) configuration |
 | `alertmanager_slack_api_url` | "" | Slack webhook url |
 | `alertmanager_pagerduty_url` | "" | Pagerduty webhook url |
-| `alertmanager_opsgenie_api_host` | "" | Opsgenie webhook url |
+| `alertmanager_opsgenie_api_key` | "" | Opsgenie webhook key |
+| `alertmanager_opsgenie_api_url` | "" | Opsgenie webhook url |
 | `alertmanager_hipchat_url` | "" | Hipchat webhook url |
 | `alertmanager_hipchat_auth_token` | "" | Hipchat authentication token |
 | `alertmanager_wechat_url` | "" | Enterprise WeChat webhook url |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,7 +29,8 @@ alertmanager_smtp: {}
 # Default values you can see here -> https://prometheus.io/docs/alerting/configuration/
 alertmanager_slack_api_url: ''
 alertmanager_pagerduty_url: ''
-alertmanager_opsgenie_api_host: ''
+alertmanager_opsgenie_api_key: ''
+alertmanager_opsgenie_api_url: ''
 alertmanager_hipchat_url: ''
 alertmanager_hipchat_auth_token: ''
 alertmanager_wechat_url: ''

--- a/templates/alertmanager.yml.j2
+++ b/templates/alertmanager.yml.j2
@@ -11,8 +11,11 @@ global:
 {% if alertmanager_pagerduty_url != '' %}
   pagerduty_url: {{ alertmanager_pagerduty_url }}
 {% endif %}
-{% if alertmanager_opsgenie_api_host != '' %}
-  opsgenie_api_host: {{ alertmanager_opsgenie_api_host }}
+{% if alertmanager_opsgenie_api_key != '' %}
+  opsgenie_api_key: {{ alertmanager_opsgenie_api_key }}
+{% endif %}
+{% if alertmanager_opsgenie_api_url != '' %}
+  opsgenie_api_url: {{ alertmanager_opsgenie_api_url }}
 {% endif %}
 {% if alertmanager_hipchat_url != '' %}
   hipchat_url: {{ alertmanager_hipchat_url }}


### PR DESCRIPTION
Update opsgenie global configuration options to match https://prometheus.io/docs/alerting/configuration/. Current option is invalid.