### PR TITLE
Move service creation from install to configure

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -10,3 +10,13 @@
     validate: "/usr/local/bin/amtool --alertmanager.url=  check-config %s"
   notify:
     - restart alertmanager
+
+- name: create systemd service unit
+  template:
+    src: alertmanager.service.j2
+    dest: /etc/systemd/system/alertmanager.service
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - restart alertmanager

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -52,16 +52,6 @@
   notify:
     - restart alertmanager
 
-- name: create systemd service unit
-  template:
-    src: alertmanager.service.j2
-    dest: /etc/systemd/system/alertmanager.service
-    owner: root
-    group: root
-    mode: 0644
-  notify:
-    - restart alertmanager
-
 - name: Install SELinux dependencies on RedHat OS family
   package:
     name: "{{ item }}"


### PR DESCRIPTION
Having the service creation in the install tasks means that changes to
the configuration, such as the web.external-url, are not updated with
the configuration task.  This creates a problem if configuration is
re-applied, either as a separate step, or re-run for updating values.
Moving the service creation to the configure step ensures any new or
updated values are taken into account in the service execution.