### PR TITLE
Add support for multi-line ansible_managed strings

### DIFF
--- a/templates/alertmanager.service.j2
+++ b/templates/alertmanager.service.j2
@@ -8,7 +8,7 @@
 {%- else %}
 {%- set cluster_flag = 'cluster' %}
 {%- endif %}
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 [Unit]
 Description=Prometheus Alertmanager
 After=network.target

--- a/templates/alertmanager.yml.j2
+++ b/templates/alertmanager.yml.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 global:
   resolve_timeout: {{ alertmanager_resolve_timeout }}


### PR DESCRIPTION
This'll support multi-line ansible_managed strings but will not work on ansible 1.x.