### PR TITLE
Download package locally during check mode

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -38,7 +38,7 @@
   delay: 2
   # run_once: true
   delegate_to: localhost
-  check_mode: no
+  check_mode: false
 
 - name: propagate alertmanager and amtool binaries
   copy:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -38,6 +38,7 @@
   delay: 2
   # run_once: true
   delegate_to: localhost
+  check_mode: no
 
 - name: propagate alertmanager and amtool binaries
   copy:


### PR DESCRIPTION
This downloads the alertmanager tarball when using this role in check mode. Otherwise, the following task, "propagate alertmanager and amtool binaries", fails due to a missing local file. 