### PR TITLE
changed 'result|success' to 'result is success' in install.yml file t…

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -61,7 +61,7 @@
     - libselinux-python
     - policycoreutils-python
   register: _download_packages
-  until: _download_packages | success
+  until: _download_packages is success
   retries: 5
   delay: 2
   when:


### PR DESCRIPTION
To avoid  warning following message:
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using `result|success` use `result is success`. This feature will be removed in version 2.9. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.