### PR TITLE
Change auth_require_tls to require_tls

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,7 +24,7 @@ alertmanager_smtp: {}
 #   auth_password: ''
 #   auth_secret: ''
 #   auth_identity: ''
-#   auth_require_tls: "True"
+#   require_tls: "True"
 
 # Default values you can see here -> https://prometheus.io/docs/alerting/configuration/
 alertmanager_slack_api_url: ''


### PR DESCRIPTION
If you use `auth_require_tls` it causes this:

```
TASK [cloudalchemy.alertmanager : copy alertmanager config] ********************************************************************************************************************
fatal: [127.0.0.1]: FAILED! => {"changed": false, "checksum": "c7cd0a8cb6995c58ecda363077ddb05886ab7942", "exit_status": 1, "msg": "failed to validate", "stderr": "amtool: error: failed to validate 1 file(s)\n\n", "stderr_lines": ["amtool: error: failed to validate 1 file(s)", ""], "stdout": "Checking '/root/.ansible/tmp/ansible-tmp-1552268526.7-265471681937283/source'  FAILED: yaml: unmarshal errors:\n  line 11: field smtp_auth_require_tls not found in type config.plain\n\n", "stdout_lines": ["Checking '/root/.ansible/tmp/ansible-tmp-1552268526.7-265471681937283/source'  FAILED: yaml: unmarshal errors:", "  line 11: field smtp_auth_require_tls not found in type config.plain", ""]}
	to retry, use: --limit @/home/user/ansible/test.retry
```

When you change it to `require_tls` it works fine.