### PR TITLE
support copying of alertmanager templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `alertmanager_db_dir` | /var/lib/alertmanager | Path to directory with alertmanager database |
 | `alertmanager_config_file` | 'alertmanager.yml.j2' | Variable used to provide custom alertmanager configuration file in form of ansible template |
 | `alertmanager_config_flags_extra` | {} | Additional configuration flags passed to prometheus binary at startup |
+| `alertmanager_template_files` | [alertmanager/templates/*.tmpl] | List of folders where ansible will look for template files which will be copied to `{{ alertmanager_config_dir }}/templates/`. Files must have `*.tmpl` extension |
 | `alertmanager_resolve_timeout` | 3m | Time after which an alert is declared resolved |
 | `alertmanager_smtp` | {} | SMTP (email) configuration |
 | `alertmanager_slack_api_url` | "" | Slack webhook url |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,9 @@ alertmanager_db_dir: /var/lib/alertmanager
 
 alertmanager_config_file: 'alertmanager.yml.j2'
 
+alertmanager_template_files:
+  - alertmanager/templates/*.tmpl
+
 alertmanager_web_listen_address: '0.0.0.0:9093'
 alertmanager_web_external_url: 'http://localhost:9093/'
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -20,3 +20,13 @@
     mode: 0644
   notify:
     - restart alertmanager
+
+- name: copy alertmanager template files
+  copy:
+    src: "{{ item }}"
+    dest: "{{ alertmanager_config_dir }}/templates/"
+    force: true
+    owner: alertmanager
+    group: alertmanager
+    mode: 0644
+  with_fileglob: "{{ alertmanager_template_files }}"

--- a/templates/alertmanager.yml.j2
+++ b/templates/alertmanager.yml.j2
@@ -39,7 +39,7 @@ global:
   wechat_api_corp_id: {{ alertmanager_wechat_corp_id | quote }}
 {% endif %}
 templates:
-- '/etc/alertmanager/templates/*.tmpl'
+- '{{ alertmanager_config_dir }}/templates/*.tmpl'
 {% if alertmanager_receivers | length %}
 receivers:
 {{ alertmanager_receivers | to_nice_yaml(indent=2) }}


### PR DESCRIPTION
Allows for management of alertmanager templates within ansible for usage by reciever messages/descriptions/etc.