### PR TITLE
update to fedora 30 and bring in mechanism for installing SELinux deps known from ansible-prometheus

### DIFF
--- a/molecule/alternative/molecule.yml
+++ b/molecule/alternative/molecule.yml
@@ -37,7 +37,7 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: fedora
-    image: paulfantom/fedora-molecule:27
+    image: paulfantom/fedora-molecule:30
     docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
     privileged: true
     volumes:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -37,7 +37,7 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: fedora
-    image: paulfantom/fedora-molecule:27
+    image: paulfantom/fedora-molecule:30
     docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
     privileged: true
     volumes:

--- a/molecule/latest/molecule.yml
+++ b/molecule/latest/molecule.yml
@@ -13,7 +13,7 @@ platforms:
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: fedora
-    image: paulfantom/fedora-molecule:27
+    image: paulfantom/fedora-molecule:30
     docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
     privileged: true
     volumes:

--- a/molecule/latest/playbook.yml
+++ b/molecule/latest/playbook.yml
@@ -6,3 +6,15 @@
     - ansible-alertmanager
   vars:
     alertmanager_version: latest
+    alertmanager_slack_api_url: "http://example.com"
+    alertmanager_receivers:
+      - name: slack
+        slack_configs:
+          - send_resolved: true
+            channel: '#alerts'
+    alertmanager_route:
+      group_by: ['alertname', 'cluster', 'service']
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 3h
+      receiver: slack

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -65,15 +65,14 @@
   package:
     name: "{{ item }}"
     state: present
-  with_items:
-    - libselinux-python
-    - policycoreutils-python
-  register: _download_packages
-  until: _download_packages is success
+  with_items: "{{ alertmanager_selinux_packages }}"
+  register: _install_packages
+  until: _install_packages is success
   retries: 5
   delay: 2
   when:
-    - ansible_os_family == "RedHat"
+    - ansible_version.full is version_compare('2.4', '>=')
+    - ansible_selinux.status == "enabled"
 
 - name: Allow alertmanager to bind to port in SELinux on RedHat OS family
   seport:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+- name: Gather variables for each operating system
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution | lower }}.yml"
+    - "{{ ansible_os_family | lower }}.yml"
+  tags:
+    - alertmanager_install
+    - alertmanager_configure
+    - alertmanager_run
+
 - include: preflight.yml
   tags:
     - alertmanager_install

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,0 +1,2 @@
+---
+alertmanager_selinux_packages: []

--- a/vars/fedora.yml
+++ b/vars/fedora.yml
@@ -1,0 +1,4 @@
+---
+alertmanager_selinux_packages:
+  - python3-libselinux
+  - python3-policycoreutils

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,0 +1,4 @@
+---
+alertmanager_selinux_packages:
+  - libselinux-python
+  - policycoreutils-python


### PR DESCRIPTION
Fedora updated to python3, so dependencies also need to be updated.

Packages for SELinux should be the same as specified in https://github.com/cloudalchemy/ansible-node-exporter/issues/95