### PR TITLE
drop testing on debian jessie and add support for debian buster

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 galaxy_info:
-  author: Roman Demachkovych
+  author: Roman Demachkovych, Pawel Krupa
   description: Prometheus Alertmanager service
   license: MIT
   company: none
@@ -14,6 +14,7 @@ galaxy_info:
       versions:
         - jessie
         - stretch
+        - buster
     - name: EL
       versions:
         - 7

--- a/molecule/alternative/molecule.yml
+++ b/molecule/alternative/molecule.yml
@@ -24,8 +24,8 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  - name: jessie
-    image: paulfantom/debian-molecule:8
+  - name: buster
+    image: paulfantom/debian-molecule:10
     docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
     privileged: true
     volumes:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -24,8 +24,8 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  - name: jessie
-    image: paulfantom/debian-molecule:8
+  - name: buster
+    image: paulfantom/debian-molecule:10
     docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
     privileged: true
     volumes:

--- a/molecule/latest/molecule.yml
+++ b/molecule/latest/molecule.yml
@@ -6,8 +6,8 @@ driver:
 lint:
   name: yamllint
 platforms:
-  - name: stretch
-    image: paulfantom/debian-molecule:9
+  - name: buster
+    image: paulfantom/debian-molecule:10
     docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
     privileged: true
     volumes:


### PR DESCRIPTION
From now on support for debian jessie is on best-effort basis. Around 30.06.2020 it will be dropped completely.

Tested locally. I will propagate it to all repos shortly.