### PR TITLE
add option to propagate binaries without access to internet

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
 | `alertmanager_version` | 0.19.0 | Alertmanager package version. Also accepts `latest` as parameter. |
+| `alertmanager_binaries_local_dir` | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `alertmanager` AND `amtool` binaries are stored on host on which ansible is ran. This overrides `alertmanager_version` parameter |
 | `alertmanager_web_listen_address` | 0.0.0.0:9093 | Address on which alertmanager will be listening |
 | `alertmanager_web_external_url` | http://localhost:9093/ | External address on which alertmanager is available. Useful when behind reverse proxy. Ex. example.org/alertmanager |
 | `alertmanager_config_dir` | /etc/alertmanager | Path to directory with alertmanager configuration |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 alertmanager_version: 0.19.0
+alertmanager_binary_local_dir: ''
 
 alertmanager_config_dir: /etc/alertmanager
 alertmanager_db_dir: /var/lib/alertmanager

--- a/molecule/alternative/playbook.yml
+++ b/molecule/alternative/playbook.yml
@@ -4,6 +4,7 @@
   roles:
     - ansible-alertmanager
   vars:
+    alertmanager_binary_local_dir: '/tmp/alertmanager-0.18.0.linux-amd64'
     alertmanager_config_dir: /opt/am/etc
     alertmanager_db_dir: /opt/am/lib
     alertmanager_web_listen_address: '127.0.0.1:9093'

--- a/molecule/alternative/playbook.yml
+++ b/molecule/alternative/playbook.yml
@@ -4,7 +4,7 @@
   roles:
     - ansible-alertmanager
   vars:
-    alertmanager_binary_local_dir: '/tmp/alertmanager-0.18.0.linux-amd64'
+    alertmanager_binary_local_dir: '/tmp/alertmanager-linux-amd64'
     alertmanager_config_dir: /opt/am/etc
     alertmanager_db_dir: /opt/am/lib
     alertmanager_web_listen_address: '127.0.0.1:9093'

--- a/molecule/alternative/prepare.yml
+++ b/molecule/alternative/prepare.yml
@@ -1,5 +1,25 @@
 ---
 - name: Prepare
-  hosts: all
+  hosts: localhost
   gather_facts: false
-  tasks: []
+  tasks:
+    - name: download alertmanager binary to local folder
+      become: false
+      get_url:
+        url: "https://github.com/prometheus/alertmanager/releases/download/v0.18.0/alertmanager-0.18.0.linux-amd64.tar.gz"
+        dest: "/tmp/alertmanager-0.18.0.linux-amd64.tar.gz"
+      register: _download_archive
+      until: _download_archive is succeeded
+      retries: 5
+      delay: 2
+      run_once: true
+      check_mode: false
+
+    - name: unpack alertmanager binaries
+      become: false
+      unarchive:
+        src: "/tmp/alertmanager-0.18.0.linux-amd64.tar.gz"
+        dest: "/tmp"
+        creates: "/tmp/alertmanager-0.18.0.linux-amd64/alertmanager"
+      run_once: true
+      check_mode: false

--- a/molecule/alternative/prepare.yml
+++ b/molecule/alternative/prepare.yml
@@ -2,12 +2,15 @@
 - name: Prepare
   hosts: localhost
   gather_facts: false
+  vars:
+    # Version seeds to be specified here as molecule doesn't have access to ansible_version at this stage
+    version: 0.19.0
   tasks:
     - name: download alertmanager binary to local folder
       become: false
       get_url:
-        url: "https://github.com/prometheus/alertmanager/releases/download/v0.18.0/alertmanager-0.18.0.linux-amd64.tar.gz"
-        dest: "/tmp/alertmanager-0.18.0.linux-amd64.tar.gz"
+        url: "https://github.com/prometheus/alertmanager/releases/download/v{{ version }}/alertmanager-{{ version }}.linux-amd64.tar.gz"
+        dest: "/tmp/alertmanager-{{ version }}.linux-amd64.tar.gz"
       register: _download_archive
       until: _download_archive is succeeded
       retries: 5
@@ -18,8 +21,17 @@
     - name: unpack alertmanager binaries
       become: false
       unarchive:
-        src: "/tmp/alertmanager-0.18.0.linux-amd64.tar.gz"
+        src: "/tmp/alertmanager-{{ version }}.linux-amd64.tar.gz"
         dest: "/tmp"
-        creates: "/tmp/alertmanager-0.18.0.linux-amd64/alertmanager"
+        creates: "/tmp/alertmanager-{{ version }}.linux-amd64/alertmanager"
+      run_once: true
+      check_mode: false
+
+    - name: link to alertmanager binaries directory
+      become: false
+      file:
+        src: "/tmp/alertmanager-{{ version }}.linux-amd64"
+        dest: "/tmp/alertmanager-linux-amd64"
+        state: link
       run_once: true
       check_mode: false

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -25,32 +25,47 @@
     - "{{ alertmanager_config_dir }}/templates"
     - "{{ alertmanager_db_dir }}"
 
-- name: download alertmanager binary to local folder
-  become: false
-  get_url:
-    url: "https://github.com/prometheus/alertmanager/releases/download/v{{ alertmanager_version }}/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch }}.tar.gz"
-    dest: "/tmp/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch }}.tar.gz"
-    checksum: "sha256:{{ alertmanager_checksum }}"
-  register: _download_archive
-  until: _download_archive is succeeded
-  retries: 5
-  delay: 2
-  # run_once: true # <-- this can't be set due to multi-arch support
-  delegate_to: localhost
-  check_mode: false
+- block:
+    - name: download alertmanager binary to local folder
+      become: false
+      get_url:
+        url: "https://github.com/prometheus/alertmanager/releases/download/v{{ alertmanager_version }}/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch }}.tar.gz"
+        dest: "/tmp/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch }}.tar.gz"
+        checksum: "sha256:{{ alertmanager_checksum }}"
+      register: _download_archive
+      until: _download_archive is succeeded
+      retries: 5
+      delay: 2
+      # run_once: true # <-- this can't be set due to multi-arch support
+      delegate_to: localhost
+      check_mode: false
 
-- name: unpack alertmanager binaries
-  become: false
-  unarchive:
-    src: "/tmp/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch }}.tar.gz"
-    dest: "/tmp"
-    creates: "/tmp/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch }}/alertmanager"
-  delegate_to: localhost
-  check_mode: false
+    - name: unpack alertmanager binaries
+      become: false
+      unarchive:
+        src: "/tmp/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch }}.tar.gz"
+        dest: "/tmp"
+        creates: "/tmp/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch }}/alertmanager"
+      delegate_to: localhost
+      check_mode: false
 
-- name: propagate alertmanager and amtool binaries
+    - name: propagate official alertmanager and amtool binaries
+      copy:
+        src: "/tmp/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch }}/{{ item }}"
+        dest: "/usr/local/bin/{{ item }}"
+        mode: 0755
+        owner: root
+        group: root
+      with_items:
+        - alertmanager
+        - amtool
+      notify:
+        - restart alertmanager
+  when: alertmanager_binary_local_dir | length == 0
+
+- name: propagate locally distributed alertmanager and amtool binaries
   copy:
-    src: "/tmp/alertmanager-{{ alertmanager_version }}.linux-{{ go_arch }}/{{ item }}"
+    src: "{{ alertmanager_binary_local_dir }}/{{ item }}"
     dest: "/usr/local/bin/{{ item }}"
     mode: 0755
     owner: root
@@ -58,6 +73,7 @@
   with_items:
     - alertmanager
     - amtool
+  when: alertmanager_binary_local_dir | length > 0
   notify:
     - restart alertmanager
 

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -35,14 +35,18 @@
     - name: "Set prometheus version to {{ _latest_release.json.tag_name[1:] }}"
       set_fact:
         alertmanager_version: "{{ _latest_release.json.tag_name[1:] }}"
-  when: alertmanager_version == "latest"
+  when:
+    - alertmanager_version == "latest"
+    - alertmanager_binary_local_path | length == 0
 
 - name: "Get checksum for {{ go_arch }} architecture"
   set_fact:
     alertmanager_checksum: "{{ item.split(' ')[0] }}"
   with_items:
     - "{{ lookup('url', 'https://github.com/prometheus/alertmanager/releases/download/v' + alertmanager_version + '/sha256sums.txt', wantlist=True) | list }}"
-  when: "('linux-' + go_arch + '.tar.gz') in item"
+  when:
+    - "('linux-' + go_arch + '.tar.gz') in item"
+    - alertmanager_binary_local_dir | length == 0
 
 - name: Backward compatibility of variable [part 1]
   set_fact:


### PR DESCRIPTION
Since this is frequently requested, I am adding an option to install alertmanager without access to github. It can be done when binaries are available on deployer host (one on which ansible is run) by specifying path to a directory containing `alertmanager` AND `amtool` binaries. Variable responsible for it is called 

It is important to notice that `alertmanager_binaries_local_dir` is a path to a directory and not to each binary.

Resolves #49

Same mechanism will be ported to other repositories.