### PR TITLE
make order of cluster args deterministic

### DIFF
--- a/templates/alertmanager.service.j2
+++ b/templates/alertmanager.service.j2
@@ -22,7 +22,7 @@ User=alertmanager
 Group=alertmanager
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/usr/local/bin/alertmanager \
-{% for option, value in alertmanager_cluster.items() %}
+{% for option, value in (alertmanager_cluster.items() | sort) %}
 {%   if option == "peers" %}
 {%     for peer in value %}
   {{ pre }}-{{ cluster_flag }}.peer={{ peer }} \


### PR DESCRIPTION
In my setup every run on the alertmanager cluster creates changes because the order for peer and and listen-address keeps being switched around-