### PR TITLE
Remove alertmanager_child_routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `alertmanager_receivers` | [] | A list of notification receivers. Configuration same as in [official docs](https://prometheus.io/docs/alerting/configuration/#<receiver>) |
 | `alertmanager_inhibit_rules` | [] | List of inhibition rules. Same as in [official docs](https://prometheus.io/docs/alerting/configuration/#inhibit_rule) |
 | `alertmanager_route` | {} | Alert routing. More in [official docs](https://prometheus.io/docs/alerting/configuration/#<route>) |
-| `alertmanager_child_routes` | [] | List of child routes. |
 
 ## Example
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -78,9 +78,6 @@ alertmanager_route: {}
 #   group_interval: 5m
 #   repeat_interval: 4h
 #   receiver: slack
-
-alertmanager_child_routes: []
-# alertmanager_child_routes:
 #   # This routes performs a regular expression match on alert labels to
 #   # catch alerts that are related to a list of services.
 #     - match_re:

--- a/molecule/alternative/playbook.yml
+++ b/molecule/alternative/playbook.yml
@@ -23,6 +23,10 @@
       group_interval: 5m
       repeat_interval: 3h
       receiver: slack
+      routes:
+        - match_re:
+            service: ^(foo1|foo2|baz)$
+          receiver: slack
     alertmanager_mesh:
       listen-address: "127.0.0.1:6783"
       peers:

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -63,6 +63,11 @@
     alertmanager_web_external_url: "{{ alertmanager_external_url }}"
   when: alertmanager_external_url is defined
 
+- name: Backward compatibility of variable [part 4]
+  set_fact:
+    alertmanager_route: "{{ alertmanager_route | combine({'routes': alertmanager_child_routes}) }}"
+  when: alertmanager_child_routes is defined
+
 - name: HA config compatibility with alertmanager<0.15.0
   set_fact:
     alertmanager_cluster: "{{ alertmanager_mesh }}"
@@ -91,7 +96,7 @@
     - alertmanager_config_file == 'alertmanager.yml.j2'
     - alertmanager_route == {}
 
-- name: Fail when child routes are defined not in proper place
-  fail:
-    msg: "Please reconfigure `alertmanager_route` so that child routes are placed in `alertmanager_child_routes`."
-  when: alertmanager_route.routes is defined
+- name: "DEPRECATION WARNING: `alertmanager_child_routes` is no longer supported"
+  debug:
+    msg: "Please move content of `alertmanager_child_routes` to `alertmanager_route.routes` as the former variable is deprecated and will be removed in future versions."
+  when: alertmanager_child_routes is defined

--- a/templates/alertmanager.yml.j2
+++ b/templates/alertmanager.yml.j2
@@ -51,7 +51,3 @@ inhibit_rules:
 {% endif %}
 route:
   {{ alertmanager_route | to_nice_yaml(indent=2) | indent(2, False) }}
-{% if alertmanager_child_routes | length %}
-  routes:
-  {{ alertmanager_child_routes | to_nice_yaml(indent=2) | indent(2, False) }}
-{% endif %}


### PR DESCRIPTION
Simplify configuration handling by removing an object which doesn't have any representation in alertmanager docs.

For backwards compatibility reasons template rendering configuration will still support `alertmanager_child_routes`. This compatibility layer should be removed after a few months (after March 2020).