### PR TITLE
Add restart handler on template change

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -30,3 +30,6 @@
     group: alertmanager
     mode: 0644
   with_fileglob: "{{ alertmanager_template_files }}"
+  notify:
+    - restart alertmanager
+


### PR DESCRIPTION
A template change also requires alertmanager to be reloaded.