### PR TITLE
Do not fail when using a custom config template file

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -80,12 +80,16 @@
 - name: Fail when there are no receivers defined
   fail:
     msg: "Configure alert receivers (`alertmanager_receivers`). Otherwise alertmanager won't know where to send alerts."
-  when: alertmanager_receivers == []
+  when:
+    - alertmanager_config_file == 'alertmanager.yml.j2'
+    - alertmanager_receivers == []
 
 - name: Fail when there is no alert route defined
   fail:
     msg: "Configure alert routing (`alertmanager_route`). Otherwise alertmanager won't know how to send alerts."
-  when: alertmanager_route == {}
+  when:
+    - alertmanager_config_file == 'alertmanager.yml.j2'
+    - alertmanager_route == {}
 
 - name: Fail when child routes are defined not in proper place
   fail:


### PR DESCRIPTION
Do not fail if `alertmanager_receivers` and `alertmanager_route` are empty while using a custom configuration template.

Since `alertmanager_config_file` is configurable it makes no sense to require these 2 variables to be non-empty if `alertmanager_config_file` is not set to its default value.