### PR TITLE
Flush handlers after configuration

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -32,5 +32,3 @@
   with_fileglob: "{{ alertmanager_template_files }}"
   notify:
     - restart alertmanager
-
-- meta: flush_handlers

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -32,3 +32,5 @@
   with_fileglob: "{{ alertmanager_template_files }}"
   notify:
     - restart alertmanager
+
+- meta: flush_handlers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,3 +30,5 @@
     enabled: true
   tags:
     - alertmanager_run
+
+- meta: flush_handlers


### PR DESCRIPTION
When combining this role with other roles in a playbook, it would seem better to apply configuration changes straight away by flushing handlers. This makes sure that if a later stage in the deployment fails, any configuration changes will still be applied. 



