### PR TITLE
add deprecation warnings

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -48,31 +48,6 @@
     - "('linux-' + go_arch + '.tar.gz') in item"
     - alertmanager_binary_local_dir | length == 0
 
-- name: Backward compatibility of variable [part 1]
-  set_fact:
-    alertmanager_config_flags_extra: "{{ alertmanager_cli_flags }}"
-  when: alertmanager_cli_flags is defined
-
-- name: Backward compatibility of variable [part 2]
-  set_fact:
-    alertmanager_web_listen_address: "{{ alertmanager_listen_address }}"
-  when: alertmanager_listen_address is defined
-
-- name: Backward compatibility of variable [part 3]
-  set_fact:
-    alertmanager_web_external_url: "{{ alertmanager_external_url }}"
-  when: alertmanager_external_url is defined
-
-- name: Backward compatibility of variable [part 4]
-  set_fact:
-    alertmanager_route: "{{ alertmanager_route | combine({'routes': alertmanager_child_routes}) }}"
-  when: alertmanager_child_routes is defined
-
-- name: HA config compatibility with alertmanager<0.15.0
-  set_fact:
-    alertmanager_cluster: "{{ alertmanager_mesh }}"
-  when: alertmanager_mesh is defined
-
 - name: Fail when extra config flags are duplicating ansible variables
   fail:
     msg: "Detected duplicate configuration entry. Please check your ansible variables and role README.md."
@@ -96,7 +71,58 @@
     - alertmanager_config_file == 'alertmanager.yml.j2'
     - alertmanager_route == {}
 
-- name: "DEPRECATION WARNING: `alertmanager_child_routes` is no longer supported"
-  debug:
+- name: "DEPRECATION WARNING: alertmanager version 0.15 and earlier are no longer supported and will be dropped from future releases"
+  ignore_errors: true
+  fail:
+    msg: "Please use `alertmanager_version >= v0.16.0`"
+  when: alertmanager_version is version_compare('0.16.0', '<')
+
+- block:
+    - name: Backward compatibility of variable [part 1]
+      set_fact:
+        alertmanager_config_flags_extra: "{{ alertmanager_cli_flags }}"
+
+    - name: "DEPRECATION WARNING: `alertmanager_cli_flags` is no longer supported and will be dropped from future releases"
+      ignore_errors: true
+      fail:
+        msg: "Please use `alertmanager_config_flags_extra` instead of `alertmanager_cli_flags`"
+  when: alertmanager_cli_flags is defined
+
+- block:
+    - name: Backward compatibility of variable [part 2]
+      set_fact:
+        alertmanager_web_listen_address: "{{ alertmanager_listen_address }}"
+
+    - name: "DEPRECATION WARNING: `alertmanager_listen_address` is no longer supported and will be dropped from future releases"
+      ignore_errors: true
+      fail:
+        msg: "Please use `alertmanager_web_listen_address` instead of `alertmanager_listen_address`"
+  when: alertmanager_listen_address is defined
+
+- block:
+    - name: Backward compatibility of variable [part 3]
+      set_fact:
+        alertmanager_web_external_url: "{{ alertmanager_external_url }}"
+
+    - name: "DEPRECATION WARNING: `alertmanager_external_url` is no longer supported and will be dropped from future releases"
+      ignore_errors: true
+      fail:
+        msg: "Please use `alertmanager_web_external_url` instead of `alertmanager_external_url`"
+  when: alertmanager_external_url is defined
+
+- block:
+    - name: HA config compatibility with alertmanager<0.15.0
+      set_fact:
+        alertmanager_cluster: "{{ alertmanager_mesh }}"
+
+    - name: "DEPRECATION WARNING: `alertmanager_mesh` is no longer supported and will be dropped from future releases"
+      ignore_errors: true
+      fail:
+        msg: "Please use `alertmanager_cluster` instead of `alertmanager_cluster`"
+  when: alertmanager_mesh is defined
+
+- name: "DEPRECATION WARNING: `alertmanager_child_routes` is no longer supported and will be dropped from future releases"
+  ignore_errors: true
+  fail:
     msg: "Please move content of `alertmanager_child_routes` to `alertmanager_route.routes` as the former variable is deprecated and will be removed in future versions."
   when: alertmanager_child_routes is defined


### PR DESCRIPTION
Apply a hacky way of showing a warning from a task \[1]. This will fail tasks, but also tolerate failure, so the user should notice the failure, but role should install alertmanager nonetheless.

Deprecation warnings should be removed with 0.19.0 release and support for alertmanager 0.15.0 with them.

\[1]: https://medium.com/opsops/how-to-print-warning-from-a-task-3286ebb39f40