### PR TITLE
Remove support for alertmanager in version before 0.15.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,12 +45,11 @@ alertmanager_wechat_corp_id: ''
 
 # First read: https://github.com/prometheus/alertmanager#high-availability
 alertmanager_cluster:
-  listen-address: ""
+  - listen-address: ""
 # alertmanager_cluster:
-#   listen-address: "{{ ansible_default_ipv4.address }}:6783"
-#   peers:
-#     - "{{ ansible_default_ipv4.address }}:6783"
-#     - "demo.cloudalchemy.org:6783"
+#   - listen-address: "{{ ansible_default_ipv4.address }}:6783"
+#   - peer: "{{ ansible_default_ipv4.address }}:6783"
+#   - peer: "demo.cloudalchemy.org:6783"
 
 alertmanager_receivers: []
 # alertmanager_receivers:

--- a/molecule/alternative/playbook.yml
+++ b/molecule/alternative/playbook.yml
@@ -27,8 +27,7 @@
         - match_re:
             service: ^(foo1|foo2|baz)$
           receiver: slack
-    alertmanager_mesh:
-      listen-address: "127.0.0.1:6783"
-      peers:
-        - "127.0.0.1:6783"
-        - "demo.cloudalchemy.org:6783"
+    alertmanager_cluster:
+      - listen-address: "127.0.0.1:6783"
+      - peer: "127.0.0.1:6783"
+      - peer: "demo.cloudalchemy.org:6783"

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -71,58 +71,9 @@
     - alertmanager_config_file == 'alertmanager.yml.j2'
     - alertmanager_route == {}
 
-- name: "DEPRECATION WARNING: alertmanager version 0.15 and earlier are no longer supported and will be dropped from future releases"
-  ignore_errors: true
+- name: "alertmanager version 0.15 is no longer supported"
   fail:
-    msg: "Please use `alertmanager_version >= v0.16.0`"
-  when: alertmanager_version is version_compare('0.16.0', '<')
-
-- block:
-    - name: Backward compatibility of variable [part 1]
-      set_fact:
-        alertmanager_config_flags_extra: "{{ alertmanager_cli_flags }}"
-
-    - name: "DEPRECATION WARNING: `alertmanager_cli_flags` is no longer supported and will be dropped from future releases"
-      ignore_errors: true
-      fail:
-        msg: "Please use `alertmanager_config_flags_extra` instead of `alertmanager_cli_flags`"
-  when: alertmanager_cli_flags is defined
-
-- block:
-    - name: Backward compatibility of variable [part 2]
-      set_fact:
-        alertmanager_web_listen_address: "{{ alertmanager_listen_address }}"
-
-    - name: "DEPRECATION WARNING: `alertmanager_listen_address` is no longer supported and will be dropped from future releases"
-      ignore_errors: true
-      fail:
-        msg: "Please use `alertmanager_web_listen_address` instead of `alertmanager_listen_address`"
-  when: alertmanager_listen_address is defined
-
-- block:
-    - name: Backward compatibility of variable [part 3]
-      set_fact:
-        alertmanager_web_external_url: "{{ alertmanager_external_url }}"
-
-    - name: "DEPRECATION WARNING: `alertmanager_external_url` is no longer supported and will be dropped from future releases"
-      ignore_errors: true
-      fail:
-        msg: "Please use `alertmanager_web_external_url` instead of `alertmanager_external_url`"
-  when: alertmanager_external_url is defined
-
-- block:
-    - name: HA config compatibility with alertmanager<0.15.0
-      set_fact:
-        alertmanager_cluster: "{{ alertmanager_mesh }}"
-
-    - name: "DEPRECATION WARNING: `alertmanager_mesh` is no longer supported and will be dropped from future releases"
-      ignore_errors: true
-      fail:
-        msg: "Please use `alertmanager_cluster` instead of `alertmanager_cluster`"
-  when: alertmanager_mesh is defined
-
-- name: "DEPRECATION WARNING: `alertmanager_child_routes` is no longer supported and will be dropped from future releases"
-  ignore_errors: true
-  fail:
-    msg: "Please move content of `alertmanager_child_routes` to `alertmanager_route.routes` as the former variable is deprecated and will be removed in future versions."
-  when: alertmanager_child_routes is defined
+    msg: "If you want to use alertmanager 0.15.0 please use ansible role in version 0.17.1 or earlier."
+  when:
+    - alertmanager_version is version_compare('0.16.0', '<')
+    - alertmanager_binary_local_dir | length == 0

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -48,31 +48,6 @@
     - "('linux-' + go_arch + '.tar.gz') in item"
     - alertmanager_binary_local_dir | length == 0
 
-- name: Backward compatibility of variable [part 1]
-  set_fact:
-    alertmanager_config_flags_extra: "{{ alertmanager_cli_flags }}"
-  when: alertmanager_cli_flags is defined
-
-- name: Backward compatibility of variable [part 2]
-  set_fact:
-    alertmanager_web_listen_address: "{{ alertmanager_listen_address }}"
-  when: alertmanager_listen_address is defined
-
-- name: Backward compatibility of variable [part 3]
-  set_fact:
-    alertmanager_web_external_url: "{{ alertmanager_external_url }}"
-  when: alertmanager_external_url is defined
-
-- name: Backward compatibility of variable [part 4]
-  set_fact:
-    alertmanager_route: "{{ alertmanager_route | combine({'routes': alertmanager_child_routes}) }}"
-  when: alertmanager_child_routes is defined
-
-- name: HA config compatibility with alertmanager<0.15.0
-  set_fact:
-    alertmanager_cluster: "{{ alertmanager_mesh }}"
-  when: alertmanager_mesh is defined
-
 - name: Fail when extra config flags are duplicating ansible variables
   fail:
     msg: "Detected duplicate configuration entry. Please check your ansible variables and role README.md."
@@ -96,7 +71,58 @@
     - alertmanager_config_file == 'alertmanager.yml.j2'
     - alertmanager_route == {}
 
-- name: "DEPRECATION WARNING: `alertmanager_child_routes` is no longer supported"
-  debug:
+- name: "DEPRECATION WARNING: alertmanager version 0.15 and earlier are no longer supported and will be dropped from future releases"
+  ignore_errors: true
+  fail:
+    msg: "Please use `alertmanager_version >= v0.16.0`"
+  when: alertmanager_version is version_compare('0.16.0', '<')
+
+- block:
+    - name: Backward compatibility of variable [part 1]
+      set_fact:
+        alertmanager_config_flags_extra: "{{ alertmanager_cli_flags }}"
+
+    - name: "DEPRECATION WARNING: `alertmanager_cli_flags` is no longer supported and will be dropped from future releases"
+      ignore_errors: true
+      fail:
+        msg: "Please use `alertmanager_config_flags_extra` instead of `alertmanager_cli_flags`"
+  when: alertmanager_cli_flags is defined
+
+- block:
+    - name: Backward compatibility of variable [part 2]
+      set_fact:
+        alertmanager_web_listen_address: "{{ alertmanager_listen_address }}"
+
+    - name: "DEPRECATION WARNING: `alertmanager_listen_address` is no longer supported and will be dropped from future releases"
+      ignore_errors: true
+      fail:
+        msg: "Please use `alertmanager_web_listen_address` instead of `alertmanager_listen_address`"
+  when: alertmanager_listen_address is defined
+
+- block:
+    - name: Backward compatibility of variable [part 3]
+      set_fact:
+        alertmanager_web_external_url: "{{ alertmanager_external_url }}"
+
+    - name: "DEPRECATION WARNING: `alertmanager_external_url` is no longer supported and will be dropped from future releases"
+      ignore_errors: true
+      fail:
+        msg: "Please use `alertmanager_web_external_url` instead of `alertmanager_external_url`"
+  when: alertmanager_external_url is defined
+
+- block:
+    - name: HA config compatibility with alertmanager<0.15.0
+      set_fact:
+        alertmanager_cluster: "{{ alertmanager_mesh }}"
+
+    - name: "DEPRECATION WARNING: `alertmanager_mesh` is no longer supported and will be dropped from future releases"
+      ignore_errors: true
+      fail:
+        msg: "Please use `alertmanager_cluster` instead of `alertmanager_cluster`"
+  when: alertmanager_mesh is defined
+
+- name: "DEPRECATION WARNING: `alertmanager_child_routes` is no longer supported and will be dropped from future releases"
+  ignore_errors: true
+  fail:
     msg: "Please move content of `alertmanager_child_routes` to `alertmanager_route.routes` as the former variable is deprecated and will be removed in future versions."
   when: alertmanager_child_routes is defined

--- a/templates/alertmanager.service.j2
+++ b/templates/alertmanager.service.j2
@@ -1,13 +1,3 @@
-{%- if alertmanager_version is version_compare('0.13.0', '>=') %}
-{%- set pre = '-' %}
-{%- else %}
-{%- set pre = '' %}
-{%- endif %}
-{%- if alertmanager_version is version_compare('0.15.0', '<') %}
-{%- set cluster_flag = 'mesh' %}
-{%- else %}
-{%- set cluster_flag = 'cluster' %}
-{%- endif %}
 {{ ansible_managed | comment }}
 [Unit]
 Description=Prometheus Alertmanager
@@ -22,20 +12,16 @@ User=alertmanager
 Group=alertmanager
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/usr/local/bin/alertmanager \
-{% for option, value in (alertmanager_cluster.items() | sort) %}
-{%   if option == "peers" %}
-{%     for peer in value %}
-  {{ pre }}-{{ cluster_flag }}.peer={{ peer }} \
-{%     endfor %}
-{%   else %}
-  {{ pre }}-{{ cluster_flag }}.{{ option }}={{ value }} \
-{%   endif %}
+{% for option in alertmanager_cluster %}
+{%   for key, value in option.items() %}
+  --cluster.{{ key }}={{ value }} \
+{%   endfor %}
 {% endfor %}
-  {{ pre }}-config.file={{ alertmanager_config_dir }}/alertmanager.yml \
-  {{ pre }}-storage.path={{ alertmanager_db_dir }} \
-  {{ pre }}-web.listen-address={{ alertmanager_web_listen_address }} \
-  {{ pre }}-web.external-url={{ alertmanager_web_external_url }}{% for flag, flag_value in alertmanager_config_flags_extra.items() %} \
-  {{ pre }}-{{ flag }}={{ flag_value }}{% endfor %}
+  --config.file={{ alertmanager_config_dir }}/alertmanager.yml \
+  --storage.path={{ alertmanager_db_dir }} \
+  --web.listen-address={{ alertmanager_web_listen_address }} \
+  --web.external-url={{ alertmanager_web_external_url }}{% for flag, flag_value in alertmanager_config_flags_extra.items() %} \
+  --{{ flag }}={{ flag_value }}{% endfor %}
 
 SyslogIdentifier=alertmanager
 Restart=always


### PR DESCRIPTION
- removing deprecation warnings
- removing support for `alertmanager_mesh`
- more readable handling of clustering syntax

merging should result in a [minor] release
