### PR TITLE
Fixed alertmanager_http_config setting failing deploy

### DIFF
--- a/templates/alertmanager.yml.j2
+++ b/templates/alertmanager.yml.j2
@@ -12,9 +12,6 @@ global:
   http_config:
     {{ alertmanager_http_config | to_nice_yaml(indent=2) | indent(4, False)}}
 {% endif %}
-{% for key, value in alertmanager_http_config.items() %}
-    {{ key }}: {{ value | quote }}
-{% endfor %}
 {% if alertmanager_pagerduty_url | length %}
   pagerduty_url: {{ alertmanager_pagerduty_url | quote }}
 {% endif %}


### PR DESCRIPTION
alertmanager_http_config was duplicated, thus template would fail to
copy because of verification