### PR TITLE
Support encrypted variables in Alertmanager template file

### DIFF
--- a/templates/alertmanager.yml.j2
+++ b/templates/alertmanager.yml.j2
@@ -5,35 +5,35 @@ global:
 {% for key, value in alertmanager_smtp.items() %}
   smtp_{{ key }}: {{ value | quote }}
 {% endfor %}
-{% if alertmanager_slack_api_url | length %}
+{% if alertmanager_slack_api_url | string | length %}
   slack_api_url: {{ alertmanager_slack_api_url | quote }}
 {% endif %}
 {% if alertmanager_http_config | length %}
   http_config:
     {{ alertmanager_http_config | to_nice_yaml(indent=2) | indent(4, False)}}
 {% endif %}
-{% if alertmanager_pagerduty_url | length %}
+{% if alertmanager_pagerduty_url | string | length %}
   pagerduty_url: {{ alertmanager_pagerduty_url | quote }}
 {% endif %}
-{% if alertmanager_opsgenie_api_key | length %}
+{% if alertmanager_opsgenie_api_key | string | length %}
   opsgenie_api_key: {{ alertmanager_opsgenie_api_key | quote }}
 {% endif %}
-{% if alertmanager_opsgenie_api_url | length %}
+{% if alertmanager_opsgenie_api_url | string | length %}
   opsgenie_api_url: {{ alertmanager_opsgenie_api_url | quote }}
 {% endif %}
-{% if alertmanager_hipchat_api_url | length %}
+{% if alertmanager_hipchat_api_url | string | length %}
   hipchat_api_url: {{ alertmanager_hipchat_api_url | quote }}
 {% endif %}
-{% if alertmanager_hipchat_auth_token | length %}
+{% if alertmanager_hipchat_auth_token | string | length %}
   hipchat_auth_token: {{ alertmanager_hipchat_auth_token | quote }}
 {% endif %}
-{% if alertmanager_wechat_url | length %}
+{% if alertmanager_wechat_url | string | length %}
   wechat_api_url: {{ alertmanager_wechat_url | quote }}
 {% endif %}
-{% if alertmanager_wechat_secret | length %}
+{% if alertmanager_wechat_secret | string | length %}
   wechat_api_secret: {{ alertmanager_wechat_secret | quote }}
 {% endif %}
-{% if alertmanager_wechat_corp_id | length %}
+{% if alertmanager_wechat_corp_id | string | length %}
   wechat_api_corp_id: {{ alertmanager_wechat_corp_id | quote }}
 {% endif %}
 templates:


### PR DESCRIPTION
Add support for encrypting variables in the Alertmanager template file.

This is a workaround for https://github.com/ansible/ansible/issues/33067, which prevents us from using encrypted variables here.

e.g. we define the OpsGenie API keys in our `group_vars/` files

```
alertmanager_opsgenie_api_key: !vault |
          $ANSIBLE_VAULT;1.1;AES256
          36633533623638323566613563663833633632626439313632336563353434623664633266306365
          3935346335393033313437333837356536306636666532310a363133616463643962663233613630
          62363731343566356366393461656433653236653435346634396131306239363339376635366230
          6537326136373436360a336439353535356436376133316239313664613434373934316265666162
          63643361313935303735333961393461653161376435316332356636326230333138
```

This change, as suggested in the above mentioned issue, allows us to use encrypted variables.