### PR TITLE
Enforce certificate validation during release version lookup

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -24,7 +24,6 @@
         return_content: true
         status_code: 200
         body_format: json
-        validate_certs: false
         user: "{{ lookup('env', 'GH_USER') | default(omit) }}"
         password: "{{ lookup('env', 'GH_TOKEN') | default(omit) }}"
       no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"


### PR DESCRIPTION
I'm not sure why it was disabled in the first place, especially because the
get_url used to download the tarball already validates certificates by default.