### PR TITLE
Revamp get latest release

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -17,23 +17,19 @@
     alertmanager_systemd_version: "{{ __systemd_version.stdout_lines[0].split(' ')[-1] }}"
 
 - block:
-    - name: Get latest release
-      uri:
-        url: "https://api.github.com/repos/prometheus/alertmanager/releases/latest"
-        method: GET
-        return_content: true
-        status_code: 200
-        body_format: json
-        user: "{{ lookup('env', 'GH_USER') | default(omit) }}"
-        password: "{{ lookup('env', 'GH_TOKEN') | default(omit) }}"
-      no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
-      register: _latest_release
-      until: _latest_release.status == 200
-      retries: 5
-
-    - name: "Set alertmanager version to {{ _latest_release.json.tag_name[1:] }}"
+    - name: Define variables to fetch latest_release metadata
       set_fact:
-        alertmanager_version: "{{ _latest_release.json.tag_name[1:] }}"
+        _url_user: "{{ lookup('env', 'GH_USER') | default(omit) }}"
+        _url_pass: "{{ lookup('env', 'GH_TOKEN') | default(omit) }}"
+        _url_dld: 'https://api.github.com/repos/prometheus/alertmanager/releases/latest'
+
+    - name: Fetch and Parse latest_release metadata
+      set_fact:
+        _latest_release: "{{ lookup('url', _url_dld, username=_url_user, pass=_url_pass) | from_json }}"
+
+    - name: "Set alertmanager version to {{ _latest_release.tag_name[1:] }}"
+      set_fact:
+        alertmanager_version: "{{ _latest_release.tag_name[1:] }}"
         alertmanager_checksum_url: "https://github.com/prometheus/alertmanager/releases/download/v{{ alertmanager_version }}/sha256sums.txt"
   when:
     - alertmanager_version == "latest"


### PR DESCRIPTION
Change how we get the latest release info in order to be able to run
the module in `check mode`.