### PR TITLE
updated to include an alertmanger_skip_install variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
 | `alertmanager_version` | 0.21.0 | Alertmanager package version. Also accepts `latest` as parameter. |
+| `alertmanager_skip_install` | false | Alertmanager installation gets skipped when set to true. |
 | `alertmanager_binary_local_dir` | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `alertmanager` AND `amtool` binaries are stored on host on which ansible is ran. This overrides `alertmanager_version` parameter |
 | `alertmanager_web_listen_address` | 0.0.0.0:9093 | Address on which alertmanager will be listening |
 | `alertmanager_web_external_url` | http://localhost:9093/ | External address on which alertmanager is available. Useful when behind reverse proxy. Ex. example.org/alertmanager |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 alertmanager_version: 0.21.0
 alertmanager_binary_local_dir: ''
+alertmanager_skip_install: false
 
 alertmanager_config_dir: /etc/alertmanager
 alertmanager_db_dir: /var/lib/alertmanager

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -63,7 +63,9 @@
         - amtool
       notify:
         - restart alertmanager
-  when: alertmanager_binary_local_dir | length == 0
+  when: 
+    - alertmanager_binary_local_dir | length == 0
+    - not alertmanager_skip_install
 
 - name: propagate locally distributed alertmanager and amtool binaries
   copy:
@@ -75,6 +77,8 @@
   with_items:
     - alertmanager
     - amtool
-  when: alertmanager_binary_local_dir | length > 0
+  when: 
+    - alertmanager_binary_local_dir | length > 0
+    - not alertmanager_skip_install
   notify:
     - restart alertmanager

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -38,6 +38,7 @@
   when:
     - alertmanager_version == "latest"
     - alertmanager_binary_local_dir | length == 0
+    - not alertmanager_skip_install
 
 - block:
     - name: "Get checksum list"
@@ -54,6 +55,7 @@
   delegate_to: localhost
   when:
     - alertmanager_binary_local_dir | length == 0
+    - not alertmanager_skip_install
 
 
 - name: Fail when extra config flags are duplicating ansible variables


### PR DESCRIPTION
I have updated the code to use the alertmanager_skip_install variable similar to the ansible-prometheus repository