### PR TITLE
Add configuration option for --web.route-prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `alertmanager_binary_local_dir` | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `alertmanager` AND `amtool` binaries are stored on host on which ansible is ran. This overrides `alertmanager_version` parameter |
 | `alertmanager_web_listen_address` | 0.0.0.0:9093 | Address on which alertmanager will be listening |
 | `alertmanager_web_external_url` | http://localhost:9093/ | External address on which alertmanager is available. Useful when behind reverse proxy. Ex. example.org/alertmanager |
+| `alermanager_web_route_prefix` | (undefined) | Prefix for the internal routes of web endpoints |
 | `alertmanager_config_dir` | /etc/alertmanager | Path to directory with alertmanager configuration |
 | `alertmanager_db_dir` | /var/lib/alertmanager | Path to directory with alertmanager database |
 | `alertmanager_config_file` | alertmanager.yml.j2 | Variable used to provide custom alertmanager configuration file in form of ansible template |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,8 @@ alertmanager_template_files:
 
 alertmanager_web_listen_address: '0.0.0.0:9093'
 alertmanager_web_external_url: 'http://localhost:9093/'
+# uncomment below to set a route prefix (--web.route-prefix)
+# alertmanager_web_route_prefix: '/'
 
 alertmanager_http_config: {}
 

--- a/templates/alertmanager.service.j2
+++ b/templates/alertmanager.service.j2
@@ -34,6 +34,9 @@ ExecStart={{ _alertmanager_binary_install_dir }}/alertmanager \
   {{ pre }}-config.file={{ alertmanager_config_dir }}/alertmanager.yml \
   {{ pre }}-storage.path={{ alertmanager_db_dir }} \
   {{ pre }}-web.listen-address={{ alertmanager_web_listen_address }} \
+{% if  alertmanager_web_route_prefix is defined %}
+  {{ pre }}-web.route-prefix={{ alertmanager_web_route_prefix }} \
+{% endif  %}
   {{ pre }}-web.external-url={{ alertmanager_web_external_url }}{% for flag, flag_value in alertmanager_config_flags_extra.items() %} \
   {{ pre }}-{{ flag }}={{ flag_value }}{% endfor %}
 


### PR DESCRIPTION
Make the --web-route-prefix parameter configurable. This is useful
when the URL configured by --web.external-url= contains a path