### PR TITLE
replaced include with import_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
-- include: preflight.yml
+- import_tasks: preflight.yml
   tags:
     - alertmanager_install
     - alertmanager_configure
     - alertmanager_run
 
-- include: install.yml
+- import_tasks: install.yml
   become: true
   tags:
     - alertmanager_install
@@ -16,7 +16,7 @@
   tags:
     - alertmanager_configure
 
-- include: configure.yml
+- import_tasks: configure.yml
   become: true
   tags:
     - alertmanager_configure


### PR DESCRIPTION
``` 
[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks instead. This feature will be removed in version 2.16. Deprecation warnings can be disabled by
setting deprecation_warnings=False in ansible.cfg.
```

replaced include with import_tasks because of deprecation warning